### PR TITLE
feat: implement Task entity with service layer, repository, DTO, and unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,5 @@ build/
 ### VS Code ###
 .vscode/
 
-### Project ###
-.env
+### Segredos e configs sensíveis
+application-secrets.properties

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+			<version>3.5.3</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/henriques/task_manager/api/Priority.java
+++ b/src/main/java/com/henriques/task_manager/api/Priority.java
@@ -1,0 +1,21 @@
+package com.henriques.task_manager.api;
+
+public enum Priority {
+    High("High"),
+    Normal("Normal"),
+    Low("Low");
+
+    private String description;
+
+    Priority(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/henriques/task_manager/api/Status.java
+++ b/src/main/java/com/henriques/task_manager/api/Status.java
@@ -1,0 +1,23 @@
+package com.henriques.task_manager.api;
+
+public enum Status {
+
+    Done("Done"),
+    InProgress("InProgress"),
+    ToDo("To Do");
+
+    private String description;
+
+    Status(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+}

--- a/src/main/java/com/henriques/task_manager/api/TaskDTO.java
+++ b/src/main/java/com/henriques/task_manager/api/TaskDTO.java
@@ -1,0 +1,89 @@
+package com.henriques.task_manager.api;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public class TaskDTO {
+
+
+    private UUID id;
+    @NotEmpty(message = "Tittle should not be empty")
+    private String title;
+    private Instant createdOn;
+    private Instant updateOn;
+    @NotEmpty(message = "Expire should not be empty, please, set a date")
+    private Instant expiredOn;
+    private Priority priority;
+    private Status status;
+    @NotEmpty(message = "Description should not be empty")
+    private String description;
+
+    public TaskDTO() {
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public Instant getCreatedOn() {
+        return createdOn;
+    }
+
+    public void setCreatedOn(Instant createdOn) {
+        this.createdOn = createdOn;
+    }
+
+    public Instant getUpdateOn() {
+        return updateOn;
+    }
+
+    public void setUpdateOn(Instant updateOn) {
+        this.updateOn = updateOn;
+    }
+
+    public Instant getExpiredOn() {
+        return expiredOn;
+    }
+
+    public void setExpiredOn(Instant expiredOn) {
+        this.expiredOn = expiredOn;
+    }
+
+    public Priority getPriority() {
+        return priority;
+    }
+
+    public void setPriority(Priority priority) {
+        this.priority = priority;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/henriques/task_manager/api/TaskDTO.java
+++ b/src/main/java/com/henriques/task_manager/api/TaskDTO.java
@@ -1,8 +1,10 @@
 package com.henriques.task_manager.api;
 
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 
 import java.time.Instant;
+import java.util.Objects;
 import java.util.UUID;
 
 public class TaskDTO {
@@ -13,7 +15,7 @@ public class TaskDTO {
     private String title;
     private Instant createdOn;
     private Instant updateOn;
-    @NotEmpty(message = "Expire should not be empty, please, set a date")
+    @NotNull(message = "Expire should not be empty, please, set a date")
     private Instant expiredOn;
     private Priority priority;
     private Status status;
@@ -86,4 +88,25 @@ public class TaskDTO {
     public void setDescription(String description) {
         this.description = description;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TaskDTO)) return false;
+        TaskDTO taskDTO = (TaskDTO) o;
+        return Objects.equals(id, taskDTO.id) &&
+                Objects.equals(title, taskDTO.title) &&
+                Objects.equals(createdOn, taskDTO.createdOn) &&
+                Objects.equals(updateOn, taskDTO.updateOn) &&
+                Objects.equals(expiredOn, taskDTO.expiredOn) &&
+                priority == taskDTO.priority &&
+                status == taskDTO.status &&
+                Objects.equals(description, taskDTO.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, title, createdOn, updateOn, expiredOn, priority, status, description);
+    }
+
 }

--- a/src/main/java/com/henriques/task_manager/convert/TaskConvert.java
+++ b/src/main/java/com/henriques/task_manager/convert/TaskConvert.java
@@ -1,4 +1,4 @@
-package com.henriques.task_manager.mapper;
+package com.henriques.task_manager.convert;
 
 import com.henriques.task_manager.api.TaskDTO;
 import com.henriques.task_manager.model.TaskEntity;
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class TaskConvert {
 
-    public TaskEntity convert(TaskDTO taskDTO) {
+    public TaskEntity convertTaskDtoToTaskEntity(TaskDTO taskDTO) {
         TaskEntity taskEntity = new TaskEntity();
 
         taskEntity.setTitle(taskDTO.getTitle());
@@ -20,7 +20,7 @@ public class TaskConvert {
         return taskEntity;
     }
 
-    public TaskDTO convert(TaskEntity taskEntity) {
+    public TaskDTO convertTaskEntityToTaskDto(TaskEntity taskEntity) {
         TaskDTO taskDTO = new TaskDTO();
         taskDTO.setId(taskEntity.getId());
         taskDTO.setTitle(taskEntity.getTitle());

--- a/src/main/java/com/henriques/task_manager/exceptions/TaskNotFoundException.java
+++ b/src/main/java/com/henriques/task_manager/exceptions/TaskNotFoundException.java
@@ -1,0 +1,11 @@
+package com.henriques.task_manager.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.NOT_FOUND)
+public class TaskNotFoundException extends RuntimeException {
+    public TaskNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/henriques/task_manager/mapper/TaskConvert.java
+++ b/src/main/java/com/henriques/task_manager/mapper/TaskConvert.java
@@ -1,0 +1,35 @@
+package com.henriques.task_manager.mapper;
+
+import com.henriques.task_manager.api.TaskDTO;
+import com.henriques.task_manager.model.TaskEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TaskConvert {
+
+    public TaskEntity convert(TaskDTO taskDTO) {
+        TaskEntity taskEntity = new TaskEntity();
+
+        taskEntity.setTitle(taskDTO.getTitle());
+        taskEntity.setStatus(taskDTO.getStatus());
+        taskEntity.setCreatedOn(taskDTO.getCreatedOn());
+        taskEntity.setExpiredOn(taskDTO.getExpiredOn());
+        taskEntity.setDescription(taskDTO.getDescription());
+        taskEntity.setPriority(taskDTO.getPriority());
+        taskEntity.setUpdateOn(taskDTO.getUpdateOn());
+        return taskEntity;
+    }
+
+    public TaskDTO convert(TaskEntity taskEntity) {
+        TaskDTO taskDTO = new TaskDTO();
+        taskDTO.setId(taskEntity.getId());
+        taskDTO.setTitle(taskEntity.getTitle());
+        taskDTO.setStatus(taskEntity.getStatus());
+        taskDTO.setCreatedOn(taskEntity.getCreatedOn());
+        taskDTO.setExpiredOn(taskEntity.getExpiredOn());
+        taskDTO.setDescription(taskEntity.getDescription());
+        taskDTO.setPriority(taskEntity.getPriority());
+        taskDTO.setUpdateOn(taskEntity.getUpdateOn());
+        return taskDTO;
+    }
+}

--- a/src/main/java/com/henriques/task_manager/model/TaskEntity.java
+++ b/src/main/java/com/henriques/task_manager/model/TaskEntity.java
@@ -8,7 +8,7 @@ import java.time.Instant;
 import java.util.UUID;
 
 @Entity
-@Table(name = "task")
+@Table(name = "task", schema = "schema_task")
 public class TaskEntity {
 
     @Id

--- a/src/main/java/com/henriques/task_manager/model/TaskEntity.java
+++ b/src/main/java/com/henriques/task_manager/model/TaskEntity.java
@@ -1,0 +1,100 @@
+package com.henriques.task_manager.model;
+
+import com.henriques.task_manager.api.Priority;
+import com.henriques.task_manager.api.Status;
+import jakarta.persistence.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "task")
+public class TaskEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", columnDefinition = "uuid")
+    private UUID id;
+    @Column(name="title")
+    private String title;
+    @Column(name="created_on")
+    private Instant createdOn;
+    @Column(name="update_on")
+    private Instant updateOn;
+    @Column(name="expired_on")
+    private Instant expiredOn;
+    @Column(name="priority")
+    @Enumerated(EnumType.STRING)
+    private Priority priority;
+    @Column(name="status")
+    private Status status;
+    @Column(name="description", columnDefinition = "TEXT", length = 300)
+    private String description;
+
+    public TaskEntity() {
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public Instant getCreatedOn() {
+        return createdOn;
+    }
+
+    public void setCreatedOn(Instant createdOn) {
+        this.createdOn = createdOn;
+    }
+
+    public Instant getUpdateOn() {
+        return updateOn;
+    }
+
+    public void setUpdateOn(Instant updateOn) {
+        this.updateOn = updateOn;
+    }
+
+    public Instant getExpiredOn() {
+        return expiredOn;
+    }
+
+    public void setExpiredOn(Instant expiredOn) {
+        this.expiredOn = expiredOn;
+    }
+
+    public Priority getPriority() {
+        return priority;
+    }
+
+    public void setPriority(Priority priority) {
+        this.priority = priority;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/henriques/task_manager/repository/TaskRepository.java
+++ b/src/main/java/com/henriques/task_manager/repository/TaskRepository.java
@@ -1,0 +1,11 @@
+package com.henriques.task_manager.repository;
+
+import com.henriques.task_manager.model.TaskEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface TaskRepository extends JpaRepository<TaskEntity, UUID> {
+}

--- a/src/main/java/com/henriques/task_manager/repository/TaskRepository.java
+++ b/src/main/java/com/henriques/task_manager/repository/TaskRepository.java
@@ -4,8 +4,11 @@ import com.henriques.task_manager.model.TaskEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface TaskRepository extends JpaRepository<TaskEntity, UUID> {
+
+    List<TaskEntity> findAllByOrderByCreatedOnDesc();
 }

--- a/src/main/java/com/henriques/task_manager/service/TaskService.java
+++ b/src/main/java/com/henriques/task_manager/service/TaskService.java
@@ -2,6 +2,8 @@ package com.henriques.task_manager.service;
 
 import com.henriques.task_manager.api.Priority;
 import com.henriques.task_manager.api.Status;
+import com.henriques.task_manager.api.TaskDTO;
+import com.henriques.task_manager.mapper.TaskConvert;
 import com.henriques.task_manager.model.TaskEntity;
 import com.henriques.task_manager.repository.TaskRepository;
 import jakarta.annotation.PostConstruct;
@@ -13,27 +15,36 @@ import java.time.Instant;
 public class TaskService {
 
     private final TaskRepository taskRepository;
+    private final TaskConvert taskConvert;
 
-    public TaskService(TaskRepository taskRepository) {
+    public TaskService(TaskRepository taskRepository, TaskConvert taskConvert) {
         this.taskRepository = taskRepository;
+        this.taskConvert = taskConvert;
     }
 
     @PostConstruct
     private void generateRandomTask() {
-        TaskEntity taskEntity = new TaskEntity();
-        taskEntity.setTitle("Tarefa Task");
-        taskEntity.setDescription("Tarefa teste.");
-        taskEntity.setStatus(Status.InProgress);
-        taskEntity.setPriority(Priority.High);
-        taskEntity.setUpdateOn(Instant.now());
-        taskEntity.setExpiredOn(Instant.now());
-        taskEntity.setCreatedOn(Instant.now());
+        TaskDTO taskDTO = new TaskDTO();
 
-        saveTask(taskEntity);
+        taskDTO.setTitle("Aula de violão");
+        taskDTO.setDescription("Praticar escala maior");
+        taskDTO.setStatus(Status.InProgress);
+        taskDTO.setPriority(Priority.Low);
+        taskDTO.setUpdateOn(Instant.now());
+        taskDTO.setExpiredOn(Instant.now());
+        taskDTO.setCreatedOn(Instant.now());
+
+        saveTask(taskDTO);
 
     }
 
-    public void saveTask(TaskEntity taskEntity) {
-        taskRepository.save(taskEntity);
+    public void saveTask(TaskDTO taskDTO) {
+
+        try {
+            TaskEntity taskEntity = taskConvert.convert(taskDTO);
+            taskRepository.save(taskEntity);
+        } catch (RuntimeException e) {
+            throw new RuntimeException("Erro ao salvar a tarefa: " + e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/henriques/task_manager/service/TaskService.java
+++ b/src/main/java/com/henriques/task_manager/service/TaskService.java
@@ -1,13 +1,10 @@
 package com.henriques.task_manager.service;
 
-import com.henriques.task_manager.api.Priority;
-import com.henriques.task_manager.api.Status;
 import com.henriques.task_manager.api.TaskDTO;
 import com.henriques.task_manager.exceptions.TaskNotFoundException;
-import com.henriques.task_manager.mapper.TaskConvert;
+import com.henriques.task_manager.convert.TaskConvert;
 import com.henriques.task_manager.model.TaskEntity;
 import com.henriques.task_manager.repository.TaskRepository;
-import jakarta.annotation.PostConstruct;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -30,7 +27,7 @@ public class TaskService {
     public void saveTask(TaskDTO taskDTO) {
 
         try {
-            TaskEntity taskEntity = taskConvert.convert(taskDTO);
+            TaskEntity taskEntity = taskConvert.convertTaskDtoToTaskEntity(taskDTO);
             taskRepository.save(taskEntity);
         } catch (RuntimeException e) {
             throw new RuntimeException("Erro ao salvar a tarefa: " + e.getMessage());
@@ -41,7 +38,7 @@ public class TaskService {
         Optional<TaskEntity> optionalTask = taskRepository.findById(id);
 
         if (optionalTask.isPresent()) {
-            return taskConvert.convert(optionalTask.get());
+            return taskConvert.convertTaskEntityToTaskDto(optionalTask.get());
         } else {
             throw new TaskNotFoundException("Task with ID " + id + " not found.");
         }
@@ -77,7 +74,7 @@ public class TaskService {
     public List<TaskDTO> getAllTasks() {
         return taskRepository.findAllByOrderByCreatedOnDesc()
                 .stream()
-                .map(taskConvert::convert)
+                .map(taskConvert::convertTaskEntityToTaskDto)
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/henriques/task_manager/service/TaskService.java
+++ b/src/main/java/com/henriques/task_manager/service/TaskService.java
@@ -1,0 +1,39 @@
+package com.henriques.task_manager.service;
+
+import com.henriques.task_manager.api.Priority;
+import com.henriques.task_manager.api.Status;
+import com.henriques.task_manager.model.TaskEntity;
+import com.henriques.task_manager.repository.TaskRepository;
+import jakarta.annotation.PostConstruct;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+
+@Service
+public class TaskService {
+
+    private final TaskRepository taskRepository;
+
+    public TaskService(TaskRepository taskRepository) {
+        this.taskRepository = taskRepository;
+    }
+
+    @PostConstruct
+    private void generateRandomTask() {
+        TaskEntity taskEntity = new TaskEntity();
+        taskEntity.setTitle("Tarefa Task");
+        taskEntity.setDescription("Tarefa teste.");
+        taskEntity.setStatus(Status.InProgress);
+        taskEntity.setPriority(Priority.High);
+        taskEntity.setUpdateOn(Instant.now());
+        taskEntity.setExpiredOn(Instant.now());
+        taskEntity.setCreatedOn(Instant.now());
+
+        saveTask(taskEntity);
+
+    }
+
+    public void saveTask(TaskEntity taskEntity) {
+        taskRepository.save(taskEntity);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,10 +1,11 @@
 spring.application.name=task-manager
+spring.config.import=optional:application-secrets.properties
 
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.hibernate.show-sql=true
 
 spring.datasource.url=jdbc:postgresql://localhost:5432/task-manager
-spring.datasource.username=${DB_USER}
-spring.datasource.password=${DB_PASSWORD}
+spring.datasource.username=${spring.datasource.username}
+spring.datasource.password=${spring.datasource.password}
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,4 @@ spring.datasource.url=jdbc:postgresql://localhost:5432/task-manager
 spring.datasource.username=${spring.datasource.username}
 spring.datasource.password=${spring.datasource.password}
 
+spring.jpa.properties.hibernate.hbm2ddl.create_namespaces=true

--- a/src/main/resources/init.sql
+++ b/src/main/resources/init.sql
@@ -1,0 +1,1 @@
+CREATE SCHEMA IF NOT EXISTS schema_task;

--- a/src/test/java/com/henriques/task_manager/service/TaskServiceTest.java
+++ b/src/test/java/com/henriques/task_manager/service/TaskServiceTest.java
@@ -1,16 +1,28 @@
 package com.henriques.task_manager.service;
 
+import com.henriques.task_manager.api.Priority;
+import com.henriques.task_manager.api.Status;
 import com.henriques.task_manager.api.TaskDTO;
 import com.henriques.task_manager.mapper.TaskConvert;
 import com.henriques.task_manager.model.TaskEntity;
 import com.henriques.task_manager.repository.TaskRepository;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 public class TaskServiceTest {
 
     @Mock
@@ -19,10 +31,6 @@ public class TaskServiceTest {
     private TaskConvert taskConvert;
     @InjectMocks
     private TaskService taskService;
-
-    public TaskServiceTest() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Test
     public void saveTaskTest() {
@@ -34,6 +42,93 @@ public class TaskServiceTest {
 
         verify(taskConvert, times(1)).convert(taskDTO);
         verify(taskRepository, times(1)).save(taskEntity);
+    }
+
+    @Test
+    public void getTaskByIdTest() {
+
+        UUID id = UUID.randomUUID();
+        TaskEntity taskEntity = new TaskEntity();
+        taskEntity.setId(id);
+
+        when(taskRepository.findById(id)).thenReturn(Optional.of(taskEntity));
+        TaskDTO taskDTO = new TaskDTO();
+        when(taskConvert.convert(taskEntity)).thenReturn(taskDTO);
+
+        TaskDTO taskDTOResult = taskService.getTaskById(id);
+
+        assertNotNull(taskDTOResult);
+        assertEquals(taskDTO, taskDTOResult);
+
+        verify(taskRepository, times(1)).findById(id);
+        verify(taskConvert, times(1)).convert(taskEntity);
+
+    }
+
+    @Test
+    public void deleteTaskTest() {
+        UUID id = UUID.randomUUID();
+        taskService.deleteTask(id);
+
+        verify(taskRepository, times(1)).deleteById(id);
+    }
+
+    @Test
+    public void updateTaskTest() {
+        TaskDTO taskDTO = new TaskDTO();
+        Instant date = Instant.parse("2023-08-21T12:00:00Z");
+
+        taskDTO.setId(UUID.randomUUID());
+        taskDTO.setTitle("Test Task Updated");
+        taskDTO.setExpiredOn(date);
+        taskDTO.setUpdateOn(date);
+        taskDTO.setCreatedOn(date);
+        taskDTO.setStatus(Status.InProgress);
+        taskDTO.setDescription("Test Description Updated");
+        taskDTO.setPriority(Priority.High);
+
+        TaskEntity existingTask = new TaskEntity();
+        existingTask.setId(taskDTO.getId());
+        existingTask.setCreatedOn(date);
+
+        when(taskRepository.findById(taskDTO.getId()))
+                .thenReturn(Optional.of(existingTask));
+
+        taskService.updateTask(taskDTO);
+
+        ArgumentCaptor<TaskEntity> taskEntityArgumentCaptor = ArgumentCaptor.forClass(TaskEntity.class);
+        verify(taskRepository, times(1)).save(taskEntityArgumentCaptor.capture());
+
+        TaskEntity taskSaved = taskEntityArgumentCaptor.getValue();
+
+        assertEquals("Test Task Updated", taskSaved.getTitle());
+        assertEquals("Test Description Updated", taskSaved.getDescription());
+        assertEquals(Status.InProgress, taskSaved.getStatus());
+        assertEquals(Priority.High, taskSaved.getPriority());
+        assertEquals(date, taskSaved.getCreatedOn());
+        assertEquals(date, taskSaved.getExpiredOn());
+        assertNotNull(taskSaved.getUpdateOn());
+    }
+
+    @Test
+    public void getTaskListTest() {
+
+        TaskEntity task1 = new TaskEntity();
+        TaskEntity task2 = new TaskEntity();
+        when(taskRepository.findAllByOrderByCreatedOnDesc()).thenReturn(List.of(task1, task2));
+
+        TaskDTO dto1 = new TaskDTO();
+        TaskDTO dto2 = new TaskDTO();
+        when(taskConvert.convert(task1)).thenReturn(dto1);
+        when(taskConvert.convert(task2)).thenReturn(dto2);
+
+        List<TaskDTO> taskDTOList = taskService.getAllTasks();
+
+        assertNotNull(taskDTOList);
+        assertEquals(2, taskDTOList.size());
+
+        verify(taskRepository, times(1)).findAllByOrderByCreatedOnDesc();
+        verify(taskConvert, times(2)).convert(any(TaskEntity.class));
     }
 
 }

--- a/src/test/java/com/henriques/task_manager/service/TaskServiceTest.java
+++ b/src/test/java/com/henriques/task_manager/service/TaskServiceTest.java
@@ -1,0 +1,39 @@
+package com.henriques.task_manager.service;
+
+import com.henriques.task_manager.api.TaskDTO;
+import com.henriques.task_manager.mapper.TaskConvert;
+import com.henriques.task_manager.model.TaskEntity;
+import com.henriques.task_manager.repository.TaskRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.Mockito.*;
+
+public class TaskServiceTest {
+
+    @Mock
+    private TaskRepository taskRepository;
+    @Mock
+    private TaskConvert taskConvert;
+    @InjectMocks
+    private TaskService taskService;
+
+    public TaskServiceTest() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void saveTaskTest() {
+        TaskDTO taskDTO = new TaskDTO();
+        TaskEntity taskEntity = new TaskEntity();
+
+        when(taskConvert.convert(taskDTO)).thenReturn(taskEntity);
+        taskService.saveTask(taskDTO);
+
+        verify(taskConvert, times(1)).convert(taskDTO);
+        verify(taskRepository, times(1)).save(taskEntity);
+    }
+
+}

--- a/src/test/java/com/henriques/task_manager/service/TaskServiceTest.java
+++ b/src/test/java/com/henriques/task_manager/service/TaskServiceTest.java
@@ -3,7 +3,7 @@ package com.henriques.task_manager.service;
 import com.henriques.task_manager.api.Priority;
 import com.henriques.task_manager.api.Status;
 import com.henriques.task_manager.api.TaskDTO;
-import com.henriques.task_manager.mapper.TaskConvert;
+import com.henriques.task_manager.convert.TaskConvert;
 import com.henriques.task_manager.model.TaskEntity;
 import com.henriques.task_manager.repository.TaskRepository;
 import org.junit.jupiter.api.Test;
@@ -37,10 +37,10 @@ public class TaskServiceTest {
         TaskDTO taskDTO = new TaskDTO();
         TaskEntity taskEntity = new TaskEntity();
 
-        when(taskConvert.convert(taskDTO)).thenReturn(taskEntity);
+        when(taskConvert.convertTaskDtoToTaskEntity(taskDTO)).thenReturn(taskEntity);
         taskService.saveTask(taskDTO);
 
-        verify(taskConvert, times(1)).convert(taskDTO);
+        verify(taskConvert, times(1)).convertTaskDtoToTaskEntity(taskDTO);
         verify(taskRepository, times(1)).save(taskEntity);
     }
 
@@ -53,7 +53,7 @@ public class TaskServiceTest {
 
         when(taskRepository.findById(id)).thenReturn(Optional.of(taskEntity));
         TaskDTO taskDTO = new TaskDTO();
-        when(taskConvert.convert(taskEntity)).thenReturn(taskDTO);
+        when(taskConvert.convertTaskEntityToTaskDto(taskEntity)).thenReturn(taskDTO);
 
         TaskDTO taskDTOResult = taskService.getTaskById(id);
 
@@ -61,7 +61,7 @@ public class TaskServiceTest {
         assertEquals(taskDTO, taskDTOResult);
 
         verify(taskRepository, times(1)).findById(id);
-        verify(taskConvert, times(1)).convert(taskEntity);
+        verify(taskConvert, times(1)).convertTaskEntityToTaskDto(taskEntity);
 
     }
 
@@ -119,8 +119,8 @@ public class TaskServiceTest {
 
         TaskDTO dto1 = new TaskDTO();
         TaskDTO dto2 = new TaskDTO();
-        when(taskConvert.convert(task1)).thenReturn(dto1);
-        when(taskConvert.convert(task2)).thenReturn(dto2);
+        when(taskConvert.convertTaskEntityToTaskDto(task1)).thenReturn(dto1);
+        when(taskConvert.convertTaskEntityToTaskDto(task2)).thenReturn(dto2);
 
         List<TaskDTO> taskDTOList = taskService.getAllTasks();
 
@@ -128,7 +128,7 @@ public class TaskServiceTest {
         assertEquals(2, taskDTOList.size());
 
         verify(taskRepository, times(1)).findAllByOrderByCreatedOnDesc();
-        verify(taskConvert, times(2)).convert(any(TaskEntity.class));
+        verify(taskConvert, times(2)).convertTaskEntityToTaskDto(any(TaskEntity.class));
     }
 
 }


### PR DESCRIPTION
This pull request includes the following implementations for the `Task` feature:

- Creation of the `TaskEntity` with JPA mapping.
- Creation of the `TaskRepository` with a custom query method (ordered by creation date).
- Implementation of the service layer (`TaskService`) with the following methods:
  - `saveTask`
  - `getTaskById`
  - `updateTask`
  - `deleteTask`
  - `getAllTasks`
- Creation of `TaskDTO` with basic field validations.
- Conversion logic between DTO and entity in the `TaskConvert` class.
- Unit tests for the service layer using JUnit and Mockito.
- Creation of the custom exception `TaskNotFoundException`.
- Project structure organized into the following packages: `model`, `repository`, `service`, `api`, `convert`, and `exceptions`.